### PR TITLE
Fix utils reference in proxmox README

### DIFF
--- a/proxmox/homelab/README.md
+++ b/proxmox/homelab/README.md
@@ -18,7 +18,6 @@ homelab/  # Project Root
 │   │   ├── iso_manager.py
 │   │   ├── vm_manager.py
 │   │   ├── main.py
-│   │   ├── utils.py
 │   │   ├── .env  <-- Environment variables file
 │── tests/
 │── .gitignore


### PR DESCRIPTION
## Summary
- remove utils.py mention from homelab README

## Testing
- `pytest -q proxmox/homelab/tests`

------
https://chatgpt.com/codex/tasks/task_e_683f8d528b4c8327b963849533b09f4b