### PR TITLE
Add ResourceManager tests

### DIFF
--- a/proxmox/homelab/tests/__init__.py
+++ b/proxmox/homelab/tests/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+import sys
+
+# Ensure the package under ../src is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/proxmox/homelab/tests/test_resource_manager.py
+++ b/proxmox/homelab/tests/test_resource_manager.py
@@ -1,0 +1,29 @@
+import pytest
+
+from homelab.resource_manager import ResourceManager
+
+
+def test_calculate_vm_resources_standard():
+    """CPU and memory should scale with provided ratios."""
+    node_info = {
+        "cpuinfo": {"cpus": 8},
+        "memory": {"total": 8 * 1024 ** 3},
+    }
+
+    cpus, memory = ResourceManager.calculate_vm_resources(node_info, 0.5, 0.5)
+
+    assert cpus == 4
+    assert memory == 4 * 1024 ** 3
+
+
+def test_calculate_vm_resources_minimums():
+    """Ensure minimum CPU and memory allocations are enforced."""
+    node_info = {
+        "cpuinfo": {"cpus": 4},
+        "memory": {"total": 4 * 1024 ** 3},
+    }
+
+    cpus, memory = ResourceManager.calculate_vm_resources(node_info, 0.0, 0.0)
+
+    assert cpus == 1
+    assert memory == 512 * 1024 ** 2


### PR DESCRIPTION
# User description
## Summary
- add pytest tests for `ResourceManager.calculate_vm_resources`
- ensure tests can import package from `src` by updating `tests/__init__.py`

## Testing
- `pytest -q proxmox/homelab/tests/test_resource_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8d5bea7083278151c106563a46db

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add test coverage for <code>ResourceManager.calculate_vm_resources</code> method which handles CPU and memory allocation calculations for VMs based on node resources and allocation ratios. Enable test infrastructure by updating Python path configuration to make the package importable from tests.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>kumar.gopal@bd.com</td><td>Initial-checkin-for-pr...</td><td>March 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @gshiva and the rest of your team on <a href=https://baz.co/changes/homeiac/home/15?tool=ast>(Baz)</a>.