### PR TITLE
Update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,8 +29,10 @@ jobs:
           cd docs
           make html
           touch build/html/.nojekyll
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build/html
   deploy:
@@ -42,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@
 place to hold all the home infrastructure as code code
 
 * [Ollama GPU Server Guide](proxmox/guides/ollama-gpu-server.md)
+* [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md)
 * [Project Documentation](https://homeiac.github.io/home/)

--- a/docs/source/md/docs_workflow_guide.md
+++ b/docs/source/md/docs_workflow_guide.md
@@ -1,0 +1,6 @@
+# Documentation Workflow Guide
+
+This guide describes how the documentation is built and deployed.
+
+The `.github/workflows/docs.yml` workflow installs Sphinx, builds the docs, and deploys the `docs/build/html` directory to GitHub Pages using the official `configure-pages`, `upload-pages-artifact`, and `deploy-pages` actions.
+


### PR DESCRIPTION
# User description
## Summary
- update docs GitHub Pages action versions
- add docs workflow guide
- link docs workflow guide from README

## Testing
- `gh issue create` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_683fc5a5906c8327ace3e4e41a3beb82

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update GitHub Pages documentation workflow by upgrading action versions (<code>configure-pages@v5</code>, <code>upload-pages-artifact@v3</code>, <code>deploy-pages@v4</code>) and add comprehensive documentation about the docs building process. Add link to the new docs workflow guide in the project's README.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gshiva</td><td>Add-workflow-to-deploy...</td><td>June 04, 2025</td></tr>
<tr><td>gshiva@hotmail.com</td><td>added-balena-cloud-pus...</td><td>May 17, 2020</td></tr></table></details>
This pull request is reviewed by Baz. Join @gshiva and the rest of your team on <a href=https://baz.co/changes/homeiac/home/19?tool=ast>(Baz)</a>.