### PR TITLE
Fix docs workflow branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ gh-pages ]
     paths:
       - 'docs/**'
       - '**/*.md'

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 place to hold all the home infrastructure as code code
 
 * [Ollama GPU Server Guide](proxmox/guides/ollama-gpu-server.md)
-* [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md)
+* [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md) - docs deploy from the `gh-pages` branch
 * [Project Documentation](https://homeiac.github.io/home/)

--- a/docs/source/md/docs_workflow_guide.md
+++ b/docs/source/md/docs_workflow_guide.md
@@ -4,3 +4,5 @@ This guide describes how the documentation is built and deployed.
 
 The `.github/workflows/docs.yml` workflow installs Sphinx, builds the docs, and deploys the `docs/build/html` directory to GitHub Pages using the official `configure-pages`, `upload-pages-artifact`, and `deploy-pages` actions.
 
+Documentation deployments run from the `gh-pages` branch. Ensure your documentation changes are pushed to that branch so the workflow can deploy them.
+


### PR DESCRIPTION
# User description
## Summary
- run GitHub Pages workflow from `gh-pages`
- document new branch requirement

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fc8fb40008327b44e467a76305501

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the GitHub Pages documentation workflow to run from the <code>gh-pages</code> branch instead of <code>master</code>. Modify documentation in the workflow guide and README to reflect this change in deployment configuration.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gshiva</td><td>Add-docs-workflow-guide-1</td><td>June 04, 2025</td></tr>
<tr><td>gshiva@hotmail.com</td><td>added-balena-cloud-pus...</td><td>May 17, 2020</td></tr></table></details>
This pull request is reviewed by Baz. Join @gshiva and the rest of your team on <a href=https://baz.co/changes/homeiac/home/20?tool=ast>(Baz)</a>.