### PR TITLE
Fix markdownlint for flux/metallb docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ place to hold all the home infrastructure as code code
 
 * [Ollama GPU Server Guide](./proxmox_guides_ollama-gpu-server.md)
 * [Proxmox WiFi Routing Guide](./proxmox_wifi_routing.md)
+* [Flux Bootstrap Guide](./proxmox_guides_flux-guide.md)
+* [MetalLB Setup Guide](./proxmox_guides_metallb-guide.md)
 * [Docs Workflow Guide](docs_workflow_guide.md) - documentation is deployed from `master` using `make -C docs html`
 * [Docs Build Guide](docs_build_guide.md) - build docs locally before pushing
 * [Docs Symlink Guide](docs_symlink_guide.md) - fix broken markdown links

--- a/docs/source/md/proxmox_guides_flux-guide.md
+++ b/docs/source/md/proxmox_guides_flux-guide.md
@@ -1,0 +1,1 @@
+../../../proxmox/guides/flux-guide.md

--- a/docs/source/md/proxmox_guides_metallb-guide.md
+++ b/docs/source/md/proxmox_guides_metallb-guide.md
@@ -1,0 +1,1 @@
+../../../proxmox/guides/metallb-guide.md

--- a/proxmox/guides/flux-guide.md
+++ b/proxmox/guides/flux-guide.md
@@ -20,12 +20,13 @@ flux bootstrap github \
 ```
 
 This installs Flux controllers and commits:
+
 - `gotk-components.yaml` & `gotk-sync.yaml` under `flux-system`
 - A `GitRepository` and initial `Kustomization`
 
 ## 3. Repository Layout
 
-```
+```text
 gitops/
 └── clusters/
     └── homelab/
@@ -37,6 +38,7 @@ gitops/
 ```
 
 `flux-system/kustomization.yaml`:
+
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -77,10 +79,12 @@ flux resume kustomization homelab -n flux-system
 
 - **Build failures** → check `path` and `apiVersion`.  
 - **Missing CRDs** → use `dependsOn` in Kustomization:
+
   ```yaml
   spec:
     dependsOn:
       - name: metallb
         namespace: flux-system
-  ```  
+  ```
+
 - **No sync** → verify `GitRepository` URL, branch, and path.

--- a/proxmox/guides/nvidia-RTX-3070-k3s-PCI-passthrough.md
+++ b/proxmox/guides/nvidia-RTX-3070-k3s-PCI-passthrough.md
@@ -121,7 +121,7 @@ sudo crictl info | grep -A3 '"nvidia"'
 nvidia-smi
 ```
 
-**NVIDIA Common Missteps From Blogs**
+### NVIDIA Common Missteps From Blogs
 
 * Editing `/etc/containerd/config.toml` (K3s ignores this file).
 * Forgetting to run `nvidia-ctk` *before* K3s starts.


### PR DESCRIPTION
## Summary
- fix lint issues in `flux-guide.md`
- ensure `nvidia-RTX-3070-k3s-PCI-passthrough.md` complies with markdownlint
- add README links and docs symlinks for flux and MetalLB guides

## Testing
- `markdownlint README.md proxmox/guides/flux-guide.md proxmox/guides/metallb-guide.md proxmox/guides/nvidia-RTX-3070-k3s-PCI-passthrough.md docs/source/md/proxmox_guides_flux-guide.md docs/source/md/proxmox_guides_metallb-guide.md`


------
https://chatgpt.com/codex/tasks/task_e_684f3fe3dfd883279b16d8dbc057e22c