### PR TITLE
Clarify monitoring storage usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ place to hold all the home infrastructure as code code
 * [Proxmox WiFi Routing Guide](./proxmox_wifi_routing.md)
 * [Flux Bootstrap Guide](./proxmox_guides_flux-guide.md)
 * [MetalLB Setup Guide](./proxmox_guides_metallb-guide.md)
+* [Monitoring Setup Guide](./proxmox_guides_monitoring-guide.md)
 * [Docs Workflow Guide](docs_workflow_guide.md) - documentation is deployed from `master` using `make -C docs html`
 * [Docs Build Guide](docs_build_guide.md) - build docs locally before pushing
 * [Docs Symlink Guide](docs_symlink_guide.md) - fix broken markdown links

--- a/docs/source/md/proxmox_guides_monitoring-guide.md
+++ b/docs/source/md/proxmox_guides_monitoring-guide.md
@@ -1,0 +1,1 @@
+../../../proxmox/guides/monitoring-guide.md

--- a/k8s/monitoring-values.yaml
+++ b/k8s/monitoring-values.yaml
@@ -18,7 +18,7 @@ prometheus:
       volumeClaimTemplate:
         spec:
           accessModes: ["ReadWriteOnce"]
-          storageClassName: longhorn
+          storageClassName: local-path
           resources:
             requests:
               storage: 100Gi

--- a/proxmox/guides/monitoring-guide.md
+++ b/proxmox/guides/monitoring-guide.md
@@ -1,0 +1,28 @@
+# Monitoring Stack Setup
+
+This guide shows how to deploy Prometheus and Grafana using the `kube-prometheus-stack` Helm chart. The default values are stored in `k8s/monitoring-values.yaml`.
+
+## Storage Considerations
+
+Prometheus generates a large write load, so running it on distributed storage like Longhorn is discouraged. Use node-local storage instead. Grafana can remain on Longhorn because it has lighter write requirements. Update `k8s/monitoring-values.yaml` so only Prometheus claims `local-path` storage:
+
+```yaml
+# k8s/monitoring-values.yaml
+grafana:
+  persistence:
+    storageClassName: longhorn
+
+prometheus:
+  prometheusSpec:
+    retention: 30d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: local-path
+          resources:
+            requests:
+              storage: 100Gi
+```
+
+Apply the Helm chart with these values to ensure data stays on each node's local disk.


### PR DESCRIPTION
## Summary
- document that Grafana can remain on Longhorn while Prometheus uses local-path
- update monitoring Helm values accordingly

## Testing
- `gh issue create` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_684f625317548327900edf30ea1d1c9c