### PR TITLE
Add Flux service for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 place to hold all the home infrastructure as code code
 
 * [Ollama GPU Server Guide](./proxmox_guides_ollama-gpu-server.md) - deploy via Flux
+* [Ollama Service Guide](./proxmox/guides/ollama-service-guide.md)
 * [Proxmox WiFi Routing Guide](./proxmox_wifi_routing.md)
 * [Flux Bootstrap Guide](./proxmox_guides_flux-guide.md)
 * [MetalLB Setup Guide](./proxmox_guides_metallb-guide.md)

--- a/docs/source/md/proxmox_guides_ollama-service-guide.md
+++ b/docs/source/md/proxmox_guides_ollama-service-guide.md
@@ -1,0 +1,7 @@
+# Ollama Service via Flux
+
+This guide shows how to expose the Ollama deployment through a Kubernetes Service managed by FluxCD.
+
+The `service-server.yaml` manifest under `gitops/clusters/homelab/apps/ollama/` selects pods labeled `app=ollama-server` and forwards port `80` to `11434`.
+
+Commit the file and Flux will create or update the service automatically.

--- a/gitops/clusters/homelab/apps/ollama/kustomization.yaml
+++ b/gitops/clusters/homelab/apps/ollama/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
+  - service-server.yaml

--- a/gitops/clusters/homelab/apps/ollama/service-server.yaml
+++ b/gitops/clusters/homelab/apps/ollama/service-server.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  selector:
+    app: ollama-server
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 11434

--- a/proxmox/guides/ollama-service-guide.md
+++ b/proxmox/guides/ollama-service-guide.md
@@ -1,0 +1,7 @@
+# Ollama Service via Flux
+
+This guide shows how to expose the Ollama deployment through a Kubernetes Service managed by FluxCD.
+
+The `service-server.yaml` manifest under `gitops/clusters/homelab/apps/ollama/` selects pods labeled `app=ollama-server` and forwards port `80` to `11434`.
+
+Commit the file and Flux will create or update the service automatically.


### PR DESCRIPTION
## Summary
- create service-server.yaml for Ollama
- register the new service with kustomize
- document the Flux service
- link to the new guide from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f6e8443f08327859fbd6facb0c22d