### PR TITLE
Add Python tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ place to hold all the home infrastructure as code code
 * [Docs Build Guide](docs/source/md/docs_build_guide.md) - build docs locally before pushing
 * [Docs Symlink Guide](docs/source/md/docs_symlink_guide.md) - fix broken markdown links
 * [Docs Publishing Guide](docs/source/md/docs_publishing_guide.md) - update the `gh-pages` branch
+* [Python Tests Guide](docs/source/md/guides/python_tests_guide.md)
 * [Project Documentation](https://homeiac.github.io/home/)
 

--- a/docs/source/md/guides/python_tests_guide.md
+++ b/docs/source/md/guides/python_tests_guide.md
@@ -1,0 +1,21 @@
+# Python Tests Guide
+
+This guide explains how to run the unit tests for the automation code.
+
+## Running Tests
+
+From the repository root run:
+
+```bash
+pytest proxmox/homelab/tests
+```
+
+The tests rely on the optional development dependencies listed in
+`proxmox/homelab/pyproject.toml`. If they are not installed, use:
+
+```bash
+pip install -r docs/requirements.txt
+pip install pytest
+```
+
+The suite covers core modules used to automate VM creation on Proxmox.

--- a/proxmox/homelab/tests/test_iso_manager.py
+++ b/proxmox/homelab/tests/test_iso_manager.py
@@ -1,0 +1,44 @@
+from unittest import mock
+
+import pytest
+
+
+def import_modules(monkeypatch, tmp_path):
+    ssh_key = tmp_path / "id_rsa.pub"
+    ssh_key.write_text("ssh-rsa AAAA")
+    monkeypatch.setenv("SSH_PUBKEY_PATH", str(ssh_key))
+    monkeypatch.setenv("API_TOKEN", "user!token=abc")
+    from homelab.iso_manager import IsoManager
+    from homelab.config import Config
+    return IsoManager, Config
+
+
+def test_download_iso(monkeypatch, tmp_path):
+    IsoManager, Config = import_modules(monkeypatch, tmp_path)
+
+    iso_path = tmp_path / "image.iso"
+    monkeypatch.setattr(Config, "ISO_NAME", str(iso_path))
+    monkeypatch.setattr(Config, "ISO_URL", "http://example.com/test.iso")
+
+    fake_resp = mock.Mock()
+    fake_resp.iter_content.return_value = [b"data"]
+
+    with mock.patch("os.path.isfile", return_value=False):
+        with mock.patch("requests.get", return_value=fake_resp) as m_get:
+            IsoManager.download_iso()
+            m_get.assert_called_once_with("http://example.com/test.iso", stream=True)
+            assert iso_path.read_bytes() == b"data"
+
+
+def test_upload_iso_to_nodes(monkeypatch, tmp_path):
+    IsoManager, Config = import_modules(monkeypatch, tmp_path)
+
+    node = {"name": "pve", "storage": "local", "img_storage": "local"}
+    monkeypatch.setattr(Config, "get_nodes", lambda: [node])
+
+    client = mock.MagicMock()
+    client.get_storage_content.return_value = []
+    monkeypatch.setattr("homelab.iso_manager.ProxmoxClient", lambda name: client)
+
+    IsoManager.upload_iso_to_nodes()
+    client.upload_iso.assert_called_once_with("local", Config.ISO_NAME)

--- a/proxmox/homelab/tests/test_vm_manager.py
+++ b/proxmox/homelab/tests/test_vm_manager.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+import pytest
+
+
+def import_vm_manager(monkeypatch, tmp_path):
+    ssh_key = tmp_path / "id_rsa.pub"
+    ssh_key.write_text("ssh-rsa AAAA")
+    monkeypatch.setenv("SSH_PUBKEY_PATH", str(ssh_key))
+    monkeypatch.setenv("API_TOKEN", "user!token=abc")
+    from homelab.vm_manager import VMManager
+    return VMManager
+
+
+def test_get_next_available_vmid(monkeypatch, tmp_path):
+    VMManager = import_vm_manager(monkeypatch, tmp_path)
+
+    proxmox = mock.MagicMock()
+    proxmox.nodes.get.return_value = [{"node": "pve1"}, {"node": "pve2"}]
+    proxmox.nodes.return_value.qemu.get.side_effect = [[{"vmid": 100}, {"vmid": 101}], [{"vmid": 200}]]
+    proxmox.nodes.return_value.lxc.get.side_effect = [[], []]
+
+    vmid = VMManager.get_next_available_vmid(proxmox)
+    assert vmid not in {100, 101, 200}


### PR DESCRIPTION
## Summary
- add unit tests for iso and vm management modules
- document how to run tests
- link the new guide in the project README

## Testing
- `pytest proxmox/homelab/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e87d9cdc8327aec723e60e2ae70d