### PR TITLE
Add stable diffusion via Flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the [Ubuntu MAAS and Proxmox Overview](docs/source/md/maas_proxmox_overview.
 
 * [Ollama GPU Server Guide](proxmox/guides/ollama-gpu-server.md) - deploy via Flux
 * [Ollama Service Guide](proxmox/guides/ollama-service-guide.md)
+* [Stable Diffusion Web UI Guide](proxmox/guides/stable-diffusion-webui-guide.md)
 * [Proxmox WiFi Routing Guide](proxmox/guides/wifi_routing.md)
 * [Flux Bootstrap Guide](proxmox/guides/flux-guide.md)
 * [MetalLB Setup Guide](proxmox/guides/metallb-guide.md)

--- a/docs/source/md/guides/stable-diffusion-webui-guide.md
+++ b/docs/source/md/guides/stable-diffusion-webui-guide.md
@@ -1,0 +1,5 @@
+# Stable Diffusion Web UI via Flux
+
+Deploy the [AUTOMATIC1111/stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) project on your cluster. FluxCD watches the manifests under `gitops/clusters/homelab/apps/stable-diffusion/` and ensures the web UI runs with GPU access.
+
+A `PersistentVolumeClaim` called `sd-models` stores models at `/stable-diffusion-webui/models`, keeping them across pod restarts.

--- a/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stable-diffusion-webui
+  namespace: stable-diffusion
+  labels:
+    app: stable-diffusion-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stable-diffusion-webui
+  template:
+    metadata:
+      labels:
+        app: stable-diffusion-webui
+    spec:
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: webui
+          image: ghcr.io/automatic1111/stable-diffusion-webui:master
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 7860
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - mountPath: /stable-diffusion-webui/models
+              name: models
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: sd-models

--- a/gitops/clusters/homelab/apps/stable-diffusion/ingress.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stable-diffusion-ingress
+  namespace: stable-diffusion
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: stable-diffusion.app.homelab
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: stable-diffusion-webui
+            port:
+              number: 80

--- a/gitops/clusters/homelab/apps/stable-diffusion/kustomization.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/gitops/clusters/homelab/apps/stable-diffusion/namespace.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stable-diffusion
+  labels:
+    app.kubernetes.io/managed-by: flux

--- a/gitops/clusters/homelab/apps/stable-diffusion/pvc.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sd-models
+  namespace: stable-diffusion
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: local-path

--- a/gitops/clusters/homelab/apps/stable-diffusion/service.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stable-diffusion-webui
+  namespace: stable-diffusion
+spec:
+  type: LoadBalancer
+  selector:
+    app: stable-diffusion-webui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 7860
+      protocol: TCP

--- a/gitops/clusters/homelab/kustomization.yaml
+++ b/gitops/clusters/homelab/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - infrastructure/monitoring            #(kube-prometheus-stack)
   - infrastructure-config/metallb-config        #(address-pool)
   - apps/ollama
+  - apps/stable-diffusion
 

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -263,3 +263,4 @@ graph TD
 - [MA90 packer-MAAS build](./guides/packer-maas-ma90.md)
 - [K3s NVIDIA GPU Passthrough Guide — Proxmox VE + K3s](./guides/nvidia-RTX-3070-k3s-PCI-passthrough.md)
 - [Ollama GPU Server Guide](./guides/ollama-gpu-server.md)
+- [Stable Diffusion Web UI Guide](./guides/stable-diffusion-webui-guide.md)

--- a/proxmox/guides/stable-diffusion-webui-guide.md
+++ b/proxmox/guides/stable-diffusion-webui-guide.md
@@ -1,0 +1,7 @@
+# Stable Diffusion Web UI via Flux
+
+This guide shows how to deploy the `stable-diffusion-webui` project using FluxCD and persist model files on local storage.
+
+The manifests live under `gitops/clusters/homelab/apps/stable-diffusion/`. Flux automatically applies the namespace, persistent volume claim, deployment, service and ingress when they are committed.
+
+Models are stored in a `PersistentVolumeClaim` named `sd-models` mounted at `/stable-diffusion-webui/models`. The PVC uses the `local-path` storage class so the files remain on the node across pod restarts.


### PR DESCRIPTION
## Summary
- deploy stable diffusion web UI through FluxCD
- persist models in a PVC so they're stored locally
- document how to run the web UI
- link new guide from READMEs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858a6a8aa40832788551278863f891c