### PR TITLE
Switch stable diffusion to universonic image

### DIFF
--- a/docs/source/md/guides/stable-diffusion-webui-guide.md
+++ b/docs/source/md/guides/stable-diffusion-webui-guide.md
@@ -1,5 +1,28 @@
 # Stable Diffusion Web UI via Flux
 
-Deploy the [AUTOMATIC1111/stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) project on your cluster. FluxCD watches the manifests under `gitops/clusters/homelab/apps/stable-diffusion/` and ensures the web UI runs with GPU access.
+Deploy the [universonic/stable-diffusion-webui](https://hub.docker.com/r/universonic/stable-diffusion-webui) container on your cluster. FluxCD watches the manifests under `gitops/clusters/homelab/apps/stable-diffusion/` and ensures the web UI runs with GPU access.
 
-A `PersistentVolumeClaim` called `sd-models` stores models at `/stable-diffusion-webui/models`, keeping them across pod restarts.
+A `PersistentVolumeClaim` called `sd-models` stores models at `/app/stable-diffusion-webui/models`, keeping them across pod restarts.
+
+## Standalone Docker Example
+
+Run the container directly for local testing:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
+Mount a data directory to persist extensions, models and outputs:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  -v /my/own/datadir/extensions:/app/stable-diffusion-webui/extensions \
+  -v /my/own/datadir/models:/app/stable-diffusion-webui/models \
+  -v /my/own/datadir/outputs:/app/stable-diffusion-webui/outputs \
+  -v /my/own/datadir/localizations:/app/stable-diffusion-webui/localizations \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
+View logs with `docker logs -f stable-diffusion-webui` if you encounter startup issues.
+

--- a/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         nvidia.com/gpu.present: "true"
       containers:
         - name: webui
-          image: ghcr.io/automatic1111/stable-diffusion-webui:master
+          image: universonic/stable-diffusion-webui:full
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7860
@@ -28,7 +28,7 @@ spec:
             limits:
               nvidia.com/gpu: "1"
           volumeMounts:
-            - mountPath: /stable-diffusion-webui/models
+            - mountPath: /app/stable-diffusion-webui/models
               name: models
       volumes:
         - name: models

--- a/proxmox/guides/stable-diffusion-webui-guide.md
+++ b/proxmox/guides/stable-diffusion-webui-guide.md
@@ -1,7 +1,33 @@
 # Stable Diffusion Web UI via Flux
 
-This guide shows how to deploy the `stable-diffusion-webui` project using FluxCD and persist model files on local storage.
+This guide shows how to deploy the `stable-diffusion-webui` project using FluxCD and persist model files on local storage. The manifests reference the Docker Hub image `universonic/stable-diffusion-webui:full`.
 
 The manifests live under `gitops/clusters/homelab/apps/stable-diffusion/`. Flux automatically applies the namespace, persistent volume claim, deployment, service and ingress when they are committed.
 
-Models are stored in a `PersistentVolumeClaim` named `sd-models` mounted at `/stable-diffusion-webui/models`. The PVC uses the `local-path` storage class so the files remain on the node across pod restarts.
+Models are stored in a `PersistentVolumeClaim` named `sd-models` mounted at `/app/stable-diffusion-webui/models`. The PVC uses the `local-path` storage class so the files remain on the node across pod restarts.
+
+## Standalone Docker Example
+
+For quick testing outside Kubernetes you can run the container directly:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
+Persist data by mounting a directory from the host:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  -v /my/own/datadir/extensions:/app/stable-diffusion-webui/extensions \
+  -v /my/own/datadir/models:/app/stable-diffusion-webui/models \
+  -v /my/own/datadir/outputs:/app/stable-diffusion-webui/outputs \
+  -v /my/own/datadir/localizations:/app/stable-diffusion-webui/localizations \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
+Check logs if the container fails to start:
+
+```bash
+docker logs -f stable-diffusion-webui
+```


### PR DESCRIPTION
## Summary
- use `universonic/stable-diffusion-webui:full` container image
- document docker run examples from Docker Hub
- update volume path to `/app/stable-diffusion-webui/models`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858d577803c8327b0e38ef9f68a4a61