### PR TITLE
Update stable diffusion service port

### DIFF
--- a/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           image: universonic/stable-diffusion-webui:full
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 7860
+            - containerPort: 8080
           resources:
             limits:
               nvidia.com/gpu: "1"

--- a/gitops/clusters/homelab/apps/stable-diffusion/service.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/service.yaml
@@ -10,5 +10,5 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 7860
+      targetPort: 8080
       protocol: TCP

--- a/proxmox/guides/stable-diffusion-webui-guide.md
+++ b/proxmox/guides/stable-diffusion-webui-guide.md
@@ -31,3 +31,9 @@ Check logs if the container fails to start:
 ```bash
 docker logs -f stable-diffusion-webui
 ```
+
+## Kubernetes Deployment
+
+The Kubernetes manifests expose the web UI on port `8080` inside the
+container. A service forwards traffic from port `80` to `8080` so you can
+access the interface via the cluster ingress.


### PR DESCRIPTION
## Summary
- update deployment and service to use container port 8080
- mention Kubernetes port mapping in stable diffusion guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858f6a1c5608327a77964716fb504a4