### PR TITLE
Fix stable diffusion extension flag

### DIFF
--- a/docs/source/md/guides/stable-diffusion-webui-guide.md
+++ b/docs/source/md/guides/stable-diffusion-webui-guide.md
@@ -24,6 +24,15 @@ docker run --gpus all --restart unless-stopped -p 8080:8080 \
   --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
 ```
 
+If you run the container with the `--share` or `--listen` options, extension installation is disabled by default.
+Pass `--enable-insecure-extension-access` through the `COMMANDLINE_ARGS` environment variable to re-enable the extensions tab:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  -e COMMANDLINE_ARGS="--enable-insecure-extension-access" \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
 View logs with `docker logs -f stable-diffusion-webui` if you encounter startup issues.
 
 ## Kubernetes Deployment

--- a/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
+++ b/gitops/clusters/homelab/apps/stable-diffusion/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         - name: webui
           image: universonic/stable-diffusion-webui:full
           imagePullPolicy: IfNotPresent
+          env:
+            - name: COMMANDLINE_ARGS
+              value: "--enable-insecure-extension-access"
           ports:
             - containerPort: 8080
           resources:

--- a/proxmox/guides/stable-diffusion-webui-guide.md
+++ b/proxmox/guides/stable-diffusion-webui-guide.md
@@ -26,6 +26,15 @@ docker run --gpus all --restart unless-stopped -p 8080:8080 \
   --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
 ```
 
+When using `--share` or `--listen`, extensions are disabled for security.
+Set `COMMANDLINE_ARGS="--enable-insecure-extension-access"` to allow installing extensions anyway:
+
+```bash
+docker run --gpus all --restart unless-stopped -p 8080:8080 \
+  -e COMMANDLINE_ARGS="--enable-insecure-extension-access" \
+  --name stable-diffusion-webui -d universonic/stable-diffusion-webui:full
+```
+
 Check logs if the container fails to start:
 
 ```bash


### PR DESCRIPTION
## Summary
- enable extension installation in `stable-diffusion-webui` deployment
- document the `--enable-insecure-extension-access` flag in guides

## Testing
- `pip install -r docs/requirements.txt`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_6859856574888327b97a6e8bd0bd661a