### PR TITLE
Add DNS host fix for OpenCloud login (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [Ubuntu MAAS and Proxmox Overview](docs/source/md/maas_proxmox_overview.
 * [Flux Bootstrap Guide](proxmox/guides/flux-guide.md)
 * [MetalLB Setup Guide](proxmox/guides/metallb-guide.md)
 * [Monitoring Setup Guide](proxmox/guides/monitoring-guide.md) - deployed via Flux
-* [OpenCloud File Manager Guide](proxmox/guides/opencloud-filemanager-guide.md) - deploy OpenCloud on k3s with Flux
+* [OpenCloud File Manager Guide](proxmox/guides/opencloud-filemanager-guide.md) - deploy OpenCloud on k3s with Flux (includes DNS login fix)
 * [Homelab Local DNS Resolution Guide](docs/source/md/homelab_local_dns_resolution_guide.md)
 * [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md) - documentation is deployed from `master` using `make -C docs html`
 * [Docs Build Guide](docs/source/md/docs_build_guide.md) - build docs locally before pushing

--- a/gitops/clusters/homelab/apps/opencloud/deployment.yaml
+++ b/gitops/clusters/homelab/apps/opencloud/deployment.yaml
@@ -17,6 +17,10 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: k3s-vm-still-fawn
+      hostAliases: # map domain locally to fix login errors (see issue #54)
+        - ip: "127.0.0.1"
+          hostnames:
+            - opencloud.app.homelab
       initContainers:
         - name: init-perms
           image: busybox

--- a/proxmox/guides/opencloud-filemanager-guide.md
+++ b/proxmox/guides/opencloud-filemanager-guide.md
@@ -2,6 +2,8 @@
 
 Deploy the [opencloudeu/opencloud-rolling](https://hub.docker.com/r/opencloudeu/opencloud-rolling) container on your k3s cluster using FluxCD. The manifests are stored under `gitops/clusters/homelab/apps/opencloud/` and create a namespace, deployment, service and ingress.
 
+If authentication fails with DNS lookup errors, see the troubleshooting section below.
+
 The container initializes its configuration on first start with `opencloud init` and then runs the server. Data is stored on the host at `/mnt/smb_data/opencloud` so files survive pod restarts. Configuration files are persisted on a Longhorn volume for redundancy. Pods are scheduled on the `k3s-vm-still-fawn` node to match the Samba permissions.
 
 ## Standalone Docker Example
@@ -20,3 +22,16 @@ docker run -p 9200:9200 \
 The files in `gitops/clusters/homelab/apps/opencloud/` define a Deployment exposing port `9200` via an Ingress at `opencloud.app.homelab`. Apply them with Flux or `kubectl apply -k`.
 
 Refer to the [OpenCloud documentation](https://docs.opencloud.eu/docs/admin/getting-started/container/docker-compose-local/) for additional environment variables and advanced configuration options.
+
+## Troubleshooting Login Errors
+
+If the OpenCloud proxy logs show errors resolving `opencloud.app.homelab`, add a host alias so the pod can resolve itself:
+
+```yaml
+hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+      - opencloud.app.homelab
+```
+
+Apply the updated deployment manifest to update the running pod. This maps the domain to `127.0.0.1` inside the container so token verification works.


### PR DESCRIPTION
## Summary
- add hostAliases to map `opencloud.app.homelab`
- document troubleshooting steps for OpenCloud login
- mention DNS login fix in README

## Testing
- `gh issue view 54 --json number,title,state,url | jq`

------
https://chatgpt.com/codex/tasks/task_e_6859e3494d208327a2be2894fed7fe2c