### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agents Guidelines
+
+This repository uses AI agents to maintain infrastructure-as-code. Follow these rules when contributing:
+
+## Commit Messages
+
+- Open a GitHub issue for each change and reference it in every commit.
+- Start with a short summary (under 50 characters).
+- Add a blank line followed by a detailed explanation.
+
+## Testing
+
+- Only run tests when Python files are modified.
+- Execute `pytest` from the repository root.
+- Measure coverage with `coverage run -m pytest` and generate reports using `coverage html`.
+- Validate types with `mypy`.
+- Check style with `flake8` and ensure formatting with `black --check`.
+
+## Markdown
+
+- Ensure all Markdown files pass `markdownlint` before committing.
+
+## Pull Requests
+
+- Keep pull requests focused and reference the related GitHub issue.
+- All checks must pass before merging.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,20 @@
 ![Deploy](https://github.com/homeiac/home/workflows/.github/workflows/deploy_to_github.yml/badge.svg)
 ![BalenaCloud Push](https://github.com/homeiac/home/workflows/BalenaCloud%20Push/badge.svg)
 
-This repository manages my homelab entirely as code so that **AI tools can manage the environment running AI workloads**. Everything from virtual machines to Kubernetes manifests is stored and documented here.
+This repository manages my homelab entirely as code so that **AI tools can manage the environment running AI workloads**.
+Everything from virtual machines to Kubernetes manifests is stored and documented here.
 
 ## Architecture Overview
 
-The design follows a layered approach. It begins with a clear **purpose**: automate and document the homelab using principles where AI manages the infrastructure that powers AI workloads. Below that sits the **automation layer** which contains Proxmox orchestration scripts, Kubernetes manifests and GitOps configuration for reproducible deployments. Next comes the **service layer** where LXC containers - created with Tteck's Proxmox VE helper scripts - and guides describe GPU servers, monitoring, and networking. Ubuntu MAAS handles bare-metal installs before nodes join Proxmox. At the base is the **documentation layer** with extensive Sphinx content explaining how everything fits together.
+The design follows a layered approach.
+It begins with a clear **purpose**: automate and document the homelab.
+AI manages the infrastructure that powers AI workloads.
+Below that sits the **automation layer** which contains Proxmox orchestration scripts,
+Kubernetes manifests and GitOps configuration for reproducible deployments.
+Next comes the **service layer** where LXC containers - created with Tteck's Proxmox VE helper scripts -
+and guides describe GPU servers, monitoring, and networking.
+Ubuntu MAAS handles bare-metal installs before nodes join Proxmox.
+At the base is the **documentation layer** with extensive Sphinx content explaining how everything fits together.
 
 ```{mermaid}
 graph TD
@@ -17,8 +26,10 @@ graph TD
     Documentation --> Purpose
 ```
 
-See the [Homelab AI Overview](docs/source/md/homelab_ai_overview.md) for a deeper explanation and additional diagrams.
-See the [Ubuntu MAAS and Proxmox Overview](docs/source/md/maas_proxmox_overview.md) for details on bare metal installs and container provisioning.
+See the [Homelab AI Overview](docs/source/md/homelab_ai_overview.md) for a deeper explanation
+and additional diagrams.
+See the [Ubuntu MAAS and Proxmox Overview](docs/source/md/maas_proxmox_overview.md)
+for details on bare metal installs and container provisioning.
 
 ## Guides
 
@@ -29,11 +40,14 @@ See the [Ubuntu MAAS and Proxmox Overview](docs/source/md/maas_proxmox_overview.
 * [Flux Bootstrap Guide](proxmox/guides/flux-guide.md)
 * [MetalLB Setup Guide](proxmox/guides/metallb-guide.md)
 * [Monitoring Setup Guide](proxmox/guides/monitoring-guide.md) - deployed via Flux
-* [OpenCloud File Manager Guide](proxmox/guides/opencloud-filemanager-guide.md) - deploy OpenCloud on k3s with Flux (includes DNS login fix)
+* [OpenCloud File Manager Guide](proxmox/guides/opencloud-filemanager-guide.md)
+  * deploy OpenCloud on k3s with Flux (includes DNS login fix)
 * [Homelab Local DNS Resolution Guide](docs/source/md/homelab_local_dns_resolution_guide.md)
-* [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md) - documentation is deployed from `master` using `make -C docs html`
+* [Docs Workflow Guide](docs/source/md/docs_workflow_guide.md)
+  * documentation is deployed from `master` using `make -C docs html`
 * [Docs Build Guide](docs/source/md/docs_build_guide.md) - build docs locally before pushing
 * [Docs Symlink Guide](docs/source/md/docs_symlink_guide.md) - fix broken markdown links
 * [Docs Publishing Guide](docs/source/md/docs_publishing_guide.md) - update the `gh-pages` branch
 * [Python Tests Guide](docs/source/md/guides/python_tests_guide.md)
+* [Agent Guidelines](docs/source/md/guides/agents_guidelines.md)
 * [Project Documentation](https://homeiac.github.io/home/)

--- a/docs/source/md/guides/agents_guidelines.md
+++ b/docs/source/md/guides/agents_guidelines.md
@@ -1,0 +1,18 @@
+# Agent Guidelines
+
+This guide explains the expectations for contributions made with or by AI agents.
+
+## Commit workflow
+
+1. Open a GitHub issue describing the change.
+2. Reference that issue in each commit message.
+3. Keep the summary under 50 characters and include a detailed description after a blank line.
+
+## Testing and quality
+
+- Run `pytest` and generate coverage reports when Python files change.
+- Check formatting with `black --check` and style with `flake8`.
+- Ensure type hints pass `mypy`.
+- All Markdown files should pass `markdownlint`.
+
+Following these steps keeps the repository consistent and reliable.


### PR DESCRIPTION
## Summary
- document contributing process in new AGENTS.md
- add an Agents Guidelines guide and link from README
- conform README to markdownlint

## Testing
- `markdownlint AGENTS.md docs/source/md/guides/agents_guidelines.md README.md`
- `make -C docs html` *(fails to fetch Python inventory but build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_685acaba1bcc83279aba0370be508993