### PR TITLE
Move Grafana DB to local storage

### DIFF
--- a/gitops/clusters/homelab/infrastructure/monitoring/monitoring-values.yaml
+++ b/gitops/clusters/homelab/infrastructure/monitoring/monitoring-values.yaml
@@ -8,7 +8,7 @@ grafana:
     accessModes:
       - ReadWriteOnce
     size: 10Gi
-    storageClassName: longhorn
+    storageClassName: local-path
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/proxmox/guides/monitoring-guide.md
+++ b/proxmox/guides/monitoring-guide.md
@@ -18,9 +18,9 @@ helm install prom-stack prometheus-community/kube-prometheus-stack \
 ## 2. Enable Persistence with local-path
 
 Prometheus generates a large write load, so running it on distributed storage like Longhorn is discouraged.
-Use node-local storage instead. Grafana can remain on Longhorn because it has lighter write requirements.
-Update `gitops/clusters/homelab/infrastructure/monitoring/monitoring-values.yaml` so only
-Prometheus claims `local-path` storage. Grafana prefers running on node
+Use node-local storage instead. Grafana's persistent volume now also uses node-local storage for simplicity.
+Update `gitops/clusters/homelab/infrastructure/monitoring/monitoring-values.yaml` so
+both Prometheus and Grafana claim `local-path` storage. Grafana prefers running on node
 `k3s-vm-still-fawn` but can fall back to any healthy node:
 
 ```yaml
@@ -31,7 +31,7 @@ grafana:
     accessModes:
       - ReadWriteOnce
     size: 10Gi
-    storageClassName: longhorn
+    storageClassName: local-path
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- use `local-path` for Grafana's PVC
- update monitoring guide accordingly

## Testing
- `markdownlint README.md proxmox/guides/monitoring-guide.md`
- `flake8`
- `mypy` *(fails: Missing target module)*
- `black --check .` *(fails: would reformat files)*

------
https://chatgpt.com/codex/tasks/task_e_687e912cc7f88327b9ca2d2e3826b730